### PR TITLE
Image order

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,7 @@
 
 ### Improvements/features:
 
-- [ ] Serve images to users based on which have the fewest annotators
+- [x] Serve images to users based on which have the fewest annotators
 - [ ] Add easily configurable customisation for the questions at the end of each image ("difficulty" etc.) in project json
 - [ ] Add configurable default model preferences in project json
 - [ ] Add helper tips for each field on Preferences tab after ~1 second mouse hover

--- a/iris/default_config.json
+++ b/iris/default_config.json
@@ -8,6 +8,7 @@
     "segmentation": {
         "mask_encoding": "rgb",
         "score": "f1",
+        "prioritise_unmarked_images":true,
         "unverified_threshold": 1,
         "test_images": null,
         "ai_model": {

--- a/iris/models.py
+++ b/iris/models.py
@@ -3,7 +3,7 @@ from random import randint
 
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from iris import db, project
+from iris import db
 
 class JsonSerializable:
     def to_json(self):

--- a/iris/project.py
+++ b/iris/project.py
@@ -461,7 +461,7 @@ class Project:
         with open(filename, 'w') as stream:
             json.dump(user_config, stream)
 
-    def get_next_image(self, image_id):
+    def get_next_image(self, image_id, user_id):
 
         original_index = self.image_ids.index(image_id)
         index = self.image_order.index(original_index)
@@ -471,7 +471,7 @@ class Project:
         # when a user asks for the next image. Then it will swap this image
         # into the existing order to make it come up next.
         if self.config['segmentation']['prioritise_unmarked_images']:
-            from iris.models import Action, User
+            from iris.models import Action
             actions = Action.query.all()
             # Same order as self.image_order (NOT self.image_ids)
             mask_count = [0]*len(self.image_order)
@@ -484,6 +484,17 @@ class Project:
                             )
                             )
                             ] += 1
+
+                if user_id.id == action.user_id:
+                    print('HIT')
+                    mask_count[
+                        self.image_order.index(
+                            self.image_ids.index(
+                                action.image_id
+                                )
+                                )
+                                ] += 9999
+
             min_labellers = min(mask_count)
             # iterate through images until one is found with fewest existing masks
             next_image_found = False

--- a/iris/segmentation/__init__.py
+++ b/iris/segmentation/__init__.py
@@ -61,7 +61,8 @@ def next_image():
     project.set_image_seed(user.image_seed)
 
     image_id = project.get_next_image(
-        flask.request.args.get('image_id', project.get_start_image_id())
+        flask.request.args.get('image_id', project.get_start_image_id()),
+        user
     )
 
     return flask.redirect(


### PR DESCRIPTION
### Summary

Adds a new strategy for selecting the next images to be annotated. When `prioritise_unmarked_images=true` in the config, the next image will be assigned dynamically, by looking for an image with the fewest number of existing masks.

### Old behaviour

- When new users signs up, create a randomly shuffled list `project.image_order` for all images in dataset
- `get_next_image()` selects image that is one after the current image in the list of images.
- `get_previous_image()` does the same in reverse, by reversing the position in the list of images by 1
-  Leads to random images getting several annotations before other images get any, because order is random for each user.

### New behaviour

- When `prioritise_unmarked_images=true`, `get_next_image()` queries database and finds image with lowest current number of associated masks. Also excludes the current image and the ones the user has already annotated. `project.image_ids` is updated by swapping the entry of the most high priority image with the ID that would have been next.
- `get_previous_image()` still works by simply reducing the index value by 1. In the immediate aftermath of a single swapping operation it will still work as expected, but after multiple swaps there is no guarantee that the reverse image order will remain fixed.
- Now, as users continue annotations, images will be served based on which has the fewest existing annotations, leading to an even spread of work across the dataset.