### PR TITLE
Production server

### DIFF
--- a/iris/__init__.py
+++ b/iris/__init__.py
@@ -129,9 +129,6 @@ def register_extensions(app):
 if len(sys.argv) > 1:
     args = parse_cmd_line()
 else:
-    args = {
-        'debug': False
-    }
     args['project'] = get_demo_file()
 
 app, db = create_app(args['project'], args)

--- a/iris/__init__.py
+++ b/iris/__init__.py
@@ -36,6 +36,7 @@ def parse_cmd_line():
         "-d", "--debug", action="store_true",
         help="start the app in debug mode"
     )
+    parser.add_argument("-p","--production", action="store_true")
     args = parser.parse_args()
 
     if args.mode == "demo":
@@ -50,9 +51,13 @@ def parse_cmd_line():
 
 def run_app():
     create_default_admin(app, db)
-
-    # webbrowser.open('http://localhost:5000/segmentation')
-    app.run(debug=project.debug, host=project['host'], port=project['port'])
+    if args['production']:
+        import gevent.pywsgi
+        app_server = gevent.pywsgi.WSGIServer((project['host'], project['port']), app)
+        print('IRIS is being served in production mode at http://{}:{}'.format(project['host'], project['port']))
+        app_server.serve_forever()
+    else:
+        app.run(debug=project.debug, host=project['host'], port=project['port'])
 
 def create_app(project_file, args):
     project.load_from(project_file)

--- a/iris/__init__.py
+++ b/iris/__init__.py
@@ -36,7 +36,9 @@ def parse_cmd_line():
         "-d", "--debug", action="store_true",
         help="start the app in debug mode"
     )
-    parser.add_argument("-p","--production", action="store_true")
+    parser.add_argument(
+        "-p","--production", action="store_true"
+        help="Use production WSGI server")
     args = parser.parse_args()
 
     if args.mode == "demo":

--- a/iris/__init__.py
+++ b/iris/__init__.py
@@ -131,6 +131,9 @@ def register_extensions(app):
 if len(sys.argv) > 1:
     args = parse_cmd_line()
 else:
+    args = {
+        'debug': False
+    }
     args['project'] = get_demo_file()
 
 app, db = create_app(args['project'], args)

--- a/iris/__init__.py
+++ b/iris/__init__.py
@@ -37,7 +37,7 @@ def parse_cmd_line():
         help="start the app in debug mode"
     )
     parser.add_argument(
-        "-p","--production", action="store_true"
+        "-p","--production", action="store_true",
         help="Use production WSGI server")
     args = parser.parse_args()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests==2.26.0
 scipy==1.7.1
 scikit-image==0.18.3
 validate_email==1.3
+gevent==22.8.0


### PR DESCRIPTION
###  Proposed solution to tangential issue in #21 

Adds a production WSGI server option to IRIS. This should help boost performance and stability when used by many concurrent users, rather than serving the application directly through a Flask development server.

Choose to serve in production mode with _-p_ _--production_ switch, e.g.:

`iris -p demo`

Behaviour defaults to previous Flask dev server if the switch is unused.