### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.8-slim-buster
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --fix-missing 
+
+RUN apt-get update && apt-get install -y gdal-bin libgdal-dev 
+
+RUN python -m pip install --upgrade pip
+
+COPY requirements.txt /requirements.txt
+
+RUN pip install --no-cache-dir -r /requirements.txt
+
+COPY . /app/
+
+RUN cd /app/ && python setup.py install
+
+ENTRYPOINT ["iris"]


### PR DESCRIPTION
A Dockerfile with all the step for the installation of the application has been created. The README should be updated in order to include the instructions for the build of the Docker container.


This is a procedure for the build:

- docker build --tag iris .

In order to run it and access the UI from the host, it is necessary to map the docker port that is used by iris (for example 5000) to a port of the host. It is also necessary to use volumes to make data persistent. 

- docker run -p 80:80 -v <dataset_path>:/dataset/ --rm -it iris label /dataset/cloud-segmentation.json


