### PR TITLE
Extend help menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Our stuff
+/projects/

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 ### Bugs (please suggest more if found)
 
 - [ ] Time spent is not logged or reported
-- [ ] Contrast/Inversion buttons toggle on but do not toggle off via mouseclick
+- [x] Contrast/Inversion buttons toggle on but do not toggle off via mouseclick
 - [x] User "admin" can revoke their admin status, this should not be possible
 - [x] Prompt to create password for user "admin" accepts blank strings, making it impossible to then log in
 

--- a/demo/cloud-segmentation.json
+++ b/demo/cloud-segmentation.json
@@ -38,16 +38,11 @@
       "name": "Cloud Shadows",
       "description": "All pixels contaminated by cloud shadows (not terrain shadows).",
       "colour": [255, 0, 0, 70]
-    },
-    {
-      "name": "No data",
-      "description": "Reserved for no data pixels, e.g. pixels outside of the satellite's swath.",
-      "colour": [50, 50, 255, 70]
     }
   ],
   "views": {
       "Cirrus": {
-          "description": "Cirrus and high clouds are red.",
+          "description": "Cirrus band. High clouds are often picked up as red.",
           "type": "image",
           "data": "$Sentinel2.B11**0.8*5",
           "cmap": "jet"
@@ -65,7 +60,7 @@
           "clip": "1"
       },
       "NRGB": {
-          "description": "Near-Infrared RGB image.",
+          "description": "Near-Infrared+GB image.",
           "type": "image",
           "data": ["$Sentinel2.B5*1.5", "$Sentinel2.B3*1.5", "$Sentinel2.B2*1.5"]
       },
@@ -97,7 +92,7 @@
       }
   },
   "view_groups": {
-      "default": ["Cirrus", "RGB", "Snow"],
+      "default": ["RGB", "Snow", "Cirrus"],
       "radar": ["Sentinel-1"]
   }
 }

--- a/iris/help/__init__.py
+++ b/iris/help/__init__.py
@@ -17,6 +17,4 @@ def index():
     return flask.render_template(
         'help.html',
         hotkeys=data.get('hotkeys', False),
-        page=data.get('page', False),
-        page_content=flask.Markup(flask.render_template(data['page_content']))
     )

--- a/iris/help/templates/help.html
+++ b/iris/help/templates/help.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -17,13 +18,14 @@
     </div>
 
     <div id='welcome' class='iris-tabs-help tabcontent' style='display:block'>
-        <p>Welcome to IRIS, a labelling tool for Sentinel-2 imagery!</p>
+        <h3>Welcome to <a href="https://github.com/esa-philab/IRIS" target="_blank">IRIS</a>, a labelling tool for satellite imagery and datacubes!</h3>
 
         <p>
-        If you're new here. Please take a moment to read this page. It will introduce you to some 
+        If you're new here, please take a moment to read this page. It will introduce you to some 
         of the basic functionality of IRIS. If you ever want to return to this page later simply 
         click <b>help</b><button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/help.png')}}" height="15" width="15"/></button>
-        at the top-right of the IRIS interface.
+        at the top-right of the IRIS interface. We recommend that you read through the following step-by-step, and go check out and explore what is described as you go along. 
+        As you do that, the <b>Hotkeys</b> tab above may be a useful companion.
         </p>
 
 
@@ -36,6 +38,66 @@
             <li><b>The Views:</b> A set of visualisations of the data to be labelled</li>
             <li><b>The Info Panel:</b> An area where useful information about the project and your labelling work is displayed</li>
         </ul>
+
+        <p>
+            As an annotator in IRIS, your job is to create a <i>segmentation mask</i> for the images you are shown. Painting all those pixels could take you a lot of time, but luckily you 
+            get to work alongside an <i>AI assistant</i>, which tries to predict the classes of areas which you haven't labelled yourself. You will be iteratively
+            labelling areas in the image with the different classes you find (what those classes are depends on the project your working on, but you can find a list of them by pressing the 
+            <button class="icon_button" onclick="dialogue_class_selection();"><img src="{{url_for('segmentation.static', filename='icons/class.png')}}" height="15" width="15"/></button> 
+            button in the toolbar). The AI assistant (a Random Forest model) will then try to predict the classes of areas which you haven't labelled yourself. You can then correct areas
+            that it gets wrong, and see if it improves when you retrain the model. You can find some tips and best practices for interacting with the AI assistant in the FAQs.
+        </p>
+
+        <p>
+            In your project, you may find multiple images displayed side by side (known as <i>views</i>). This is because IRIS can label data that are not just the standard red-green-blue images we are used to,
+            but also images with multiple different bands. These could be different spectral channels (e.g. Infrared), or different information entirely, like maps, elevation data, or 
+            anything else that you can put on a 2D surface. The creators of a project can define as many views as they like, using those different data sources. IRIS gives you the ability to switch between the
+            different pre-defined views, and create whole groups of views that you can switch between easily.
+        </p>
+
+
+        <h3>Getting Started</h3>
+
+        <p>In the following, a typical workflow for a user will be described. Feel free to go sequentially through the points and try them for yourself.</p>
+
+        <h4>1. Look around!</h4>
+        <p>
+            Use the zoom <span class='key'>Scrollwheel</span> and navigation<span class='key'>W</span> tools to take a closer look at the data in front of you. Select a few different views (<span class='key'>V</span>)
+            and see what they look like. Is it too dark? Too bright? You can use the brightness, saturation and contrast controls located in the toolbar to help you!
+        </p>
+
+        <h4>2. Select a class</h4>
+        <p>
+            Now that you've had a look around, you've probably noticed a few things you'd like to start labelling. Select a class from the list of classes in the toolbar. You can also use the <span class='key'>1..9</span> keys.
+        </p>
+
+        <h4>3. Start painting!</h4>
+        <p>
+            Using the draw tool, and adjusting the paintbrush size with <span class='key'>Shift+scrollwheel</span>, try painting a few pixels from two or three different classes. Keep it simple, just a few is fine! The classes 
+            you draw will be highlighted in different colours. If you don't see anything, it might be because that class is defined without a colour. You can still see your annotations though, in the <i>user mask</i>
+            <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/mask_user.png')}}" height="15" width="15"/></button>/<span class='key'>G</span>.
+        </p>
+
+        <h4>4. Train your AI assistant</h4>
+        <p>
+            Now that you've labelled a few pixels, you can train your AI assistant. Click the <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/ai.png')}}" height="15" width="15"/></button>/<span class='key'>A</span>
+            button in the toolbar, and see what happens! You can use the spacebar to toggle the mask's visibility.
+        </p>
+
+        <h4>5. Correct your AI assistant</h4>
+        <p>
+            Using all the navigation, visualisation, and labelling skills you've just practiced, go ahead and make a few corrections to what the AI predicted. It probably made some mistakes in areas of the image that are 
+            different to the areas you originally labelled. That's fine! You can just keep retraining and correcting your AI assistant as you go!
+        </p>
+
+        <h4>6. Save your work</h4>
+        <p>
+            When you're done, don't forget to save your work! You can do this by clicking the <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/save_mask.png')}}" height="15" width="15"/></button>/<span class='key'>S</span>
+            button in the toolbar. You can then come back and finish the image any time you like. Or, you can move on to the next image in the project by clicking the <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/next.png')}}" height="15" width="15"/></button>/<span class='key'>Enter</span>
+            button.
+        </p>
+
+        For more tips and advanced use, check out the FAQs.
 
     </div>
 
@@ -51,19 +113,83 @@
     </div>
 
     <div id='faqs' class='iris-tabs-help tabcontent'>
+        <br>
         <h2>Annotating Images</h2>
-        <h4>How can I change the size of the pencil?</h4>
+        <h3>I'm painting pixels, but nothing's happening!</h3>
+        <p>
+            In some projects (including, for example, IRIS' demo) there is a class that is in some sense the background or default, which one does not want to visualise with a coloured overlay. For example, in the case of cloud masking with satellite imagery, pixels
+            for which we can clearly see the surface, and for which no cloud is present, it is much easier to visualise as a clear colour. Upon loading, IRIS defaults to showing you an overlay of the <i>final mask</i> which may use no colour for one of the classes. However,
+            you can switch to the <i>user mask</i> by pressing <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/mask_user.png')}}" height="15" width="15"/></button><b>/</b><span class="key">G</span>. In the <i>user mask</i>, 
+            one should be able to see more clearly where annotations by the user have been made.
+        </p>
+
+        <p>
+            If there is still nothing showing, then make sure you are using the <i>draw tool</i><button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/pencil.png')}}" height="15" width="15"/></button><b>/</b><span class="key">D</span>, and
+            that your mask is is set to be visible <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/show_mask.png')}}" height="15" width="15"/></button><b>/</b><span class="key">Space</span>
+        </p>
+
+        <h3>How can I change the size of the pencil?</h3>
         Press <span class="key">Shift</span> while scrolling the mouse wheel.
-        <h4>I would like to undo some changes. How can I do that?</h4>
+        <h3>I would like to undo some changes. How can I do that?</h3>
         Use either the undo<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/undo.png')}}" height="15" width="15"/></button><b>/</b><span class="key">U</span> command  or the eraser<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/eraser.png')}}" height="15" width="15"/></button>/<span class="key">E</span>.
-        <h4>How can I select another class for drawing?</h4>
+        <h3>How can I select another class for drawing?</h3>
         Use either the number hotkeys (<span class="key">1..9</span>) or click <button class="icon_button" onclick="dialogue_class_selection();"><img src="{{url_for('segmentation.static', filename='icons/class.png')}}" height="15" width="15"/></button> in the toolbar.
+        
+        
+        <br><br>
         <h2>Saving and Loading</h2>
-        <h4>Does IRIS save my progress?</h4>
+        <h3>Does IRIS save my progress when I leave?</h3>
         It is possible to lose your progress whilst annotating in IRIS, if you navigate away from the page or close the browser without doing one of the following:
         <ul>
             <li>Clicking save<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/save_mask.png')}}" height="15" width="15"/></button> at the top-left of the IRIS interface. This will allow you to come back to the same image and mask later, as if you had never stopped working on it.</li>
             <li>Going to the next or previous image.</li>
+        </ul>
+        <h3>How are images ordered?</h3>
+            The IRIS project can be set up with two different image ordering modes:
+            <ul>
+                <li><b>Random:</b> Images are shown in a random order, with the order fixed for each different user (meaning you will always find images in the same order when you come back).</li>
+                <li><b>Prioritise least annotated:</b> Images that are the least annotated are prioritised, so that you are shown images which need more annotations. This can change the order of images dynamically.</li>
+            </ul>
+            The project administrator can change the image ordering mode on the server by editing the project's configuration files, this cannot be altered by a user.
+        <h3>What is the questionnaire that appears after I have finished an image?</h3>
+        <p>
+            The short questionnaire offers you an opportunity to make any notes about the image. This may be useful at a later point for quality control or organisation. The difficulty bar is a useful way to qualitatively rate
+            how you think the labelling went. Checking the box to say that your mask is complete will mark that image as complete for you, and you will not be shown that image again (although if you exhaust all available images 
+            then the completed ones may be shown to you again). If you do not check the box, then IRIS will keep track of the fact that you would still like to work on this image later.
+        </p>
+
+        <br><br>
+        <h2>Interacting with the AI</h2>
+        <h3>The AI doesn't seem to be learning what I want it to learn</h3>
+        <p>
+            The AI Assistant in IRIS can be a powerful tool when used correctly.There are several ways one can help the AI model to perform better, however, it will always have limitations in certain situations
+            which may have to be resolved through manual intervention, rather than using the model's predictions. Some of the ways to help the AI are:
+        </p>
+            
+        <ul>
+            <li><b>Providing high quality labels</b> helps the model by guiding it in its learning process. If the model is struggling to learn over a specific kind of area in the image, try to provide examples
+            from those areas. Counterintuitively, more training data is not always better. Try to provide the model with a diverse set of pixels, rather than a large number of pixels from the same class and the same
+            colour/type of pixel in the image. </li> 
+            <li><b>Altering the model parameters</b> can have a big effect on the model's performance. When training data are too few, an overly large model can overfit and produce strange outputs. Meanwhile, if 
+            many difficult and diverse labels are given, then the model may struggle to learn the complex relationships between input and output if it is too small. These parameters can be adjusted from the Preferences
+            menu in the top-right of the IRIS interface (the cog icon)<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/preferences.png')}}" height="15" width="15"/></button>.</li> 
+            <li><b>Changing the bands</b> used by the model can stop the model from overfitting to input data that is not particularly relevant to the annotations of that image. Like the model's parameters, the bands can be included
+            and excluded in the Preferences menu.</li> 
+            <li><b>Post-processing the results</b> with the <i>suppression filter</i> can remove the small (a few pixels wide) areas that the AI assistant picks up. This can be useful to make the mask appear more smooth. However,
+            it should be used with caution, if those small regions are important for the dataset's application.</li>
+        </ul>
+
+        <h3>The information panel keeps telling me to provide more pixels of a certain class</h3>
+        <p>
+            The AI assistant computes a confusion matrix using a percentage of the labels you provide, to see how well it is doing in matching your annotations. If the model is struggling with a specific class, then it will prompt 
+            you to label more of it. However, what often happens is that the class it desires more labels from is just the most difficult class to label in the image. In this case, the tooltip will continue to ask for more of that
+            class indefinitely, even if a large number of labels is provided. Don't worry if this happens, the AI assistant is never quite satisfied with what you give it, or its own performance!
+        </p>
+        <h3>I keep labelling more pixels, but the accuracy displayed in the information panel is decreasing!</h3>
+        <p>
+            This is perfectly natural. If you are selecting areas to label based on mistakes the model is making, then you are continuously creating a harder and harder set of pixels for the model to learn from and validate itself
+            with. If anything, a model performance of close to 100% should be more concerning than a lower one, as it may be overfitting to the training data.
+        </p>
     </div>
 
     <div id='about' class='iris-tabs-help tabcontent'>

--- a/iris/help/templates/help.html
+++ b/iris/help/templates/help.html
@@ -85,10 +85,10 @@
             Use the zoom <span class='key'>Scrollwheel</span> and navigation<span class='key'>W</span> tools to take a closer look at the data in front of you. Is it too dark? Too bright? You can use the brightness, saturation and contrast controls located in the toolbar to help you!
         </p>
 
-        <h4>2. Change the views</h4>
+        <h4>2. Change the view</h4>
         <p>
-        Select a few different views with the <span class='key'>V</span> key and see what they look like. There might be information that's useful which you can't see in the views you
-        initially see! Have a think about the features you can see in the different views, and how they might be useful for labelling.
+        Select a few different views with the <span class='key'>V</span> key and see what they look like. There might be information that's useful which you can't see in the views you are
+        initially given! Have a think about the features you can see in the different views, and how they might be useful for labelling. Try using the image adjustment tools mentioned in the previous step too, to make the views as clear as possible.
         </p>
 
         <h4>3. Select a class</h4>

--- a/iris/help/templates/help.html
+++ b/iris/help/templates/help.html
@@ -55,6 +55,11 @@
             different pre-defined views, and create whole groups of views that you can switch between easily.
         </p>
 
+        <p>
+            After you get to annotating, the mask that you and your AI assistant create will be displayed as an overlay on top of the image. This is so that you can see simultaneously your labels and what they correspond
+            to in the data below. Each class will have been assigned a colour by your project administrator. 
+        </p>
+
         <br>
         <h2>Getting Started</h2>
 
@@ -115,10 +120,10 @@
             You and your AI assistant will be more effective as a team if you keep in mind it's strengths and weaknesses. Here are some tips and tricks to get the best out of your new colleague.
         </p>
         
-        <h4>1. Input Output</h4>
+        <h4>1. Input -> Output</h4>
         <p>
             The model only learns from what you give it, so diverse labels will help the model learn about all the different areas in the image, don't just stick to annotating one kind of mistake. Quality over quantity is preferred,
-            as errors in the labels can confuse the model. 
+            as errors in the labels can confuse the model. What you put in is what you get out!
         </p>
 
         <p>
@@ -127,7 +132,7 @@
             <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/preferences.png')}}" height="15" width="15"/></button>, you can add a post-processing step which filters out small areas with
             different classes. This effectively smooths your output spatially, and may help if you have lots of noisy model errors that are difficult to correct manually.
         </p>
-        <h4>2. Taking advice</h4>
+        <h4>2. Listening Skills</h4>
         
         <p>
             Your AI assistant might suggest a class to annotate more of in the right-hand side box of the Information Panel, this can be a useful tip to follow if you're not sure what to do. It gives this advice based on its assessment of how it
@@ -135,12 +140,10 @@
         </p>
         <p>
             An accuracy score and confusion matrix can also be found in the Information Panel (once the model is trained). This gives you an idea of how well the model is performing, on a set of pixels held out from training. This doesn't necessarily indicate
-            its performance in areas you haven't annotated: we can't know that. However, it can give you an idea of how well the model is performing in general, and how well it is performing in the classes you have annotated. If you think its struggling and has
-            a low accuracy, you can also try changing the model parameters in the Preferences menu <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/preferences.png')}}" height="15" width="15"/></button>.
+            its performance in areas you haven't annotated: we can't know that. However, it can give you some measure of the model's success. If you think its struggling and has
+            a low accuracy, you can also try changing the model parameters in the Preferences menu <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/preferences.png')}}" height="15" width="15"/></button>. Low accuracy
+            isn't necessarily a bad thing, and you will usually find the accuracy <i>decreasing</i> over time, because you are adding more and more difficult labels.
         </p>
-
-        
-
 
         For more tips and advanced use, check out the FAQs.
 

--- a/iris/help/templates/help.html
+++ b/iris/help/templates/help.html
@@ -23,7 +23,7 @@
         <p>
         If you're new here, please take a moment to read this page. It will introduce you to some 
         of the basic functionality of IRIS. If you ever want to return to this page later simply 
-        click <b>help</b><button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/help.png')}}" height="15" width="15"/></button>
+        click <b>help</b> <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/help.png')}}" height="15" width="15"/></button>
         at the top-right of the IRIS interface. We recommend that you read through the following step-by-step, and go check out and explore what is described as you go along. 
         As you do that, the <b>Hotkeys</b> tab above may be a useful companion.
         </p>
@@ -55,47 +55,92 @@
             different pre-defined views, and create whole groups of views that you can switch between easily.
         </p>
 
-
-        <h3>Getting Started</h3>
+        <br>
+        <h2>Getting Started</h2>
 
         <p>In the following, a typical workflow for a user will be described. Feel free to go sequentially through the points and try them for yourself.</p>
 
         <h4>1. Look around!</h4>
         <p>
-            Use the zoom <span class='key'>Scrollwheel</span> and navigation<span class='key'>W</span> tools to take a closer look at the data in front of you. Select a few different views (<span class='key'>V</span>)
-            and see what they look like. Is it too dark? Too bright? You can use the brightness, saturation and contrast controls located in the toolbar to help you!
+            Use the zoom <span class='key'>Scrollwheel</span> and navigation<span class='key'>W</span> tools to take a closer look at the data in front of you. Is it too dark? Too bright? You can use the brightness, saturation and contrast controls located in the toolbar to help you!
         </p>
 
-        <h4>2. Select a class</h4>
+        <h4>2. Change the views</h4>
+        <p>
+        Select a few different views with the <span class='key'>V</span> key and see what they look like. There might be information that's useful which you can't see in the views you
+        initially see! Have a think about the features you can see in the different views, and how they might be useful for labelling.
+        </p>
+
+        <h4>3. Select a class</h4>
         <p>
             Now that you've had a look around, you've probably noticed a few things you'd like to start labelling. Select a class from the list of classes in the toolbar. You can also use the <span class='key'>1..9</span> keys.
         </p>
 
-        <h4>3. Start painting!</h4>
+        <h4>4. Start painting!</h4>
         <p>
             Using the draw tool, and adjusting the paintbrush size with <span class='key'>Shift+scrollwheel</span>, try painting a few pixels from two or three different classes. Keep it simple, just a few is fine! The classes 
-            you draw will be highlighted in different colours. If you don't see anything, it might be because that class is defined without a colour. You can still see your annotations though, in the <i>user mask</i>
-            <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/mask_user.png')}}" height="15" width="15"/></button>/<span class='key'>G</span>.
+            you draw will be highlighted in different colours. 
+        </p>
+        
+        <h4>5. Display the mask</h4>
+        <p>
+            IRIS's mask comes from a combination of hand-drawn labels, and AI-generated predictions. When you begin annotating an image, these will be blank, but when they are populated they are displayed as a semi-transparent overlay above 
+            the image views. You can view either the combined predictions between human and model, known as the final mask <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/mask_final.png')}}" height="15" width="15"/></button>/(<span class='key'>F</span>),
+            or only the annotations you've made, known as the user mask <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/mask_user.png')}}" height="15" width="15"/></button>/<span class='key'>G</span>. 
+            Try selecting the user mask mode before you begin annotating.
         </p>
 
-        <h4>4. Train your AI assistant</h4>
+        <h4>5. Train your AI assistant</h4>
         <p>
             Now that you've labelled a few pixels, you can train your AI assistant. Click the <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/ai.png')}}" height="15" width="15"/></button>/<span class='key'>A</span>
-            button in the toolbar, and see what happens! You can use the spacebar to toggle the mask's visibility.
+            button in the toolbar, and see what happens! You can use the tools from Step 5 to display the AI predictions, and the spacebar to toggle the mask transparency, allowing you to see the image below easily.
         </p>
 
-        <h4>5. Correct your AI assistant</h4>
+        <h4>6. Correct your AI assistant</h4>
         <p>
             Using all the navigation, visualisation, and labelling skills you've just practiced, go ahead and make a few corrections to what the AI predicted. It probably made some mistakes in areas of the image that are 
             different to the areas you originally labelled. That's fine! You can just keep retraining and correcting your AI assistant as you go!
         </p>
 
-        <h4>6. Save your work</h4>
+        <h4>7. Save your work</h4>
         <p>
             When you're done, don't forget to save your work! You can do this by clicking the <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/save_mask.png')}}" height="15" width="15"/></button>/<span class='key'>S</span>
             button in the toolbar. You can then come back and finish the image any time you like. Or, you can move on to the next image in the project by clicking the <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/next.png')}}" height="15" width="15"/></button>/<span class='key'>Enter</span>
             button.
         </p>
+
+        <br><br>
+        <h2>Think like a robot</h2>
+        <p>
+            You and your AI assistant will be more effective as a team if you keep in mind it's strengths and weaknesses. Here are some tips and tricks to get the best out of your new colleague.
+        </p>
+        
+        <h4>1. Input Output</h4>
+        <p>
+            The model only learns from what you give it, so diverse labels will help the model learn about all the different areas in the image, don't just stick to annotating one kind of mistake. Quality over quantity is preferred,
+            as errors in the labels can confuse the model. 
+        </p>
+
+        <p>
+            Something else to keep in mind is that each pixel in the image that you label is a training example for the model. This means that the model doesn't understand <i>spatial</i> relationships between pixels. This means if there
+            are classes which strongly depend on textural information, it may be difficult for the model to perform well (unless the project administrator has somehow embedded this spatial information in each pixel). In the Preferences menu
+            <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/preferences.png')}}" height="15" width="15"/></button>, you can add a post-processing step which filters out small areas with
+            different classes. This effectively smooths your output spatially, and may help if you have lots of noisy model errors that are difficult to correct manually.
+        </p>
+        <h4>2. Taking advice</h4>
+        
+        <p>
+            Your AI assistant might suggest a class to annotate more of in the right-hand side box of the Information Panel, this can be a useful tip to follow if you're not sure what to do. It gives this advice based on its assessment of how it
+            is performing in the different classes. However, if a class is inherently more difficult than others, it will keep asking for annotations even when they are not necessarily helpful, so take what it says onboard but don't feel you need to follow it.
+        </p>
+        <p>
+            An accuracy score and confusion matrix can also be found in the Information Panel (once the model is trained). This gives you an idea of how well the model is performing, on a set of pixels held out from training. This doesn't necessarily indicate
+            its performance in areas you haven't annotated: we can't know that. However, it can give you an idea of how well the model is performing in general, and how well it is performing in the classes you have annotated. If you think its struggling and has
+            a low accuracy, you can also try changing the model parameters in the Preferences menu <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/preferences.png')}}" height="15" width="15"/></button>.
+        </p>
+
+        
+
 
         For more tips and advanced use, check out the FAQs.
 
@@ -124,14 +169,14 @@
         </p>
 
         <p>
-            If there is still nothing showing, then make sure you are using the <i>draw tool</i><button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/pencil.png')}}" height="15" width="15"/></button><b>/</b><span class="key">D</span>, and
+            If there is still nothing showing, then make sure you are using the <i>draw tool</i> <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/pencil.png')}}" height="15" width="15"/></button><b>/</b><span class="key">D</span>, and
             that your mask is is set to be visible <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/show_mask.png')}}" height="15" width="15"/></button><b>/</b><span class="key">Space</span>
         </p>
 
         <h3>How can I change the size of the pencil?</h3>
         Press <span class="key">Shift</span> while scrolling the mouse wheel.
         <h3>I would like to undo some changes. How can I do that?</h3>
-        Use either the undo<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/undo.png')}}" height="15" width="15"/></button><b>/</b><span class="key">U</span> command  or the eraser<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/eraser.png')}}" height="15" width="15"/></button>/<span class="key">E</span>.
+        Use either the undo <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/undo.png')}}" height="15" width="15"/></button><b>/</b><span class="key">U</span> command  or the eraser <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/eraser.png')}}" height="15" width="15"/></button>/<span class="key">E</span>.
         <h3>How can I select another class for drawing?</h3>
         Use either the number hotkeys (<span class="key">1..9</span>) or click <button class="icon_button" onclick="dialogue_class_selection();"><img src="{{url_for('segmentation.static', filename='icons/class.png')}}" height="15" width="15"/></button> in the toolbar.
         
@@ -141,7 +186,7 @@
         <h3>Does IRIS save my progress when I leave?</h3>
         It is possible to lose your progress whilst annotating in IRIS, if you navigate away from the page or close the browser without doing one of the following:
         <ul>
-            <li>Clicking save<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/save_mask.png')}}" height="15" width="15"/></button> at the top-left of the IRIS interface. This will allow you to come back to the same image and mask later, as if you had never stopped working on it.</li>
+            <li>Clicking save <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/save_mask.png')}}" height="15" width="15"/></button> at the top-left of the IRIS interface. This will allow you to come back to the same image and mask later, as if you had never stopped working on it.</li>
             <li>Going to the next or previous image.</li>
         </ul>
         <h3>How are images ordered?</h3>

--- a/iris/help/templates/help.html
+++ b/iris/help/templates/help.html
@@ -11,17 +11,36 @@
 <body>
     <div class="tab">
         <button class="tablinks checked" onclick="open_tab(this, 'help', 'welcome');">Welcome</button>
-        <button class="tablinks" onclick="open_tab(this, 'help', 'page');">{{page}}</button>
+        <button class="tablinks" onclick="open_tab(this, 'help', 'faqs');">FAQs</button>
         <button class="tablinks" onclick="open_tab(this, 'help', 'hotkeys');">Hotkeys</button>
         <button class="tablinks" onclick="open_tab(this, 'help', 'about');">About</button>
     </div>
 
     <div id='welcome' class='iris-tabs-help tabcontent' style='display:block'>
-        Welcome to IRIS, a labelling tool for Sentinel-2 imagery.
+        <p>Welcome to IRIS, a labelling tool for Sentinel-2 imagery!</p>
+
+        <p>
+        If you're new here. Please take a moment to read this page. It will introduce you to some 
+        of the basic functionality of IRIS. If you ever want to return to this page later simply 
+        click <b>help</b><button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/help.png')}}" height="15" width="15"/></button>
+        at the top-right of the IRIS interface.
+        </p>
+
+
+        <h3>Basic Overview</h3>
+
+        <p>The IRIS interface consists of three main parts, starting from the top of the screen:</p>
+
+        <ul>
+            <li><b>The Toolbar:</b> Contains all the tools for drawing and editing masks, as well as manipulating and moving around the image</li>
+            <li><b>The Views:</b> A set of visualisations of the data to be labelled</li>
+            <li><b>The Info Panel:</b> An area where useful information about the project and your labelling work is displayed</li>
+        </ul>
+
     </div>
 
     <div id='hotkeys' class='iris-tabs-help tabcontent'>
-        <table>
+        <table class=striped>
             <tr><td><b>Command</b></td><td><b>Key</b></td></tr>
             {% for key, description in hotkeys.items() %}
                 <tr><td>{{description}}</td>
@@ -31,14 +50,26 @@
         </table>
     </div>
 
-    <div id='page' class='iris-tabs-help tabcontent'>
-    {{page_content}}
+    <div id='faqs' class='iris-tabs-help tabcontent'>
+        <h2>Annotating Images</h2>
+        <h4>How can I change the size of the pencil?</h4>
+        Press <span class="key">Shift</span> while scrolling the mouse wheel.
+        <h4>I would like to undo some changes. How can I do that?</h4>
+        Use either the undo<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/undo.png')}}" height="15" width="15"/></button><b>/</b><span class="key">U</span> command  or the eraser<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/eraser.png')}}" height="15" width="15"/></button>/<span class="key">E</span>.
+        <h4>How can I select another class for drawing?</h4>
+        Use either the number hotkeys (<span class="key">1..9</span>) or click <button class="icon_button" onclick="dialogue_class_selection();"><img src="{{url_for('segmentation.static', filename='icons/class.png')}}" height="15" width="15"/></button> in the toolbar.
+        <h2>Saving and Loading</h2>
+        <h4>Does IRIS save my progress?</h4>
+        It is possible to lose your progress whilst annotating in IRIS, if you navigate away from the page or close the browser without doing one of the following:
+        <ul>
+            <li>Clicking save<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/save_mask.png')}}" height="15" width="15"/></button> at the top-left of the IRIS interface. This will allow you to come back to the same image and mask later, as if you had never stopped working on it.</li>
+            <li>Going to the next or previous image.</li>
     </div>
 
     <div id='about' class='iris-tabs-help tabcontent'>
         IRIS was developed by
         <p>John Mrziglod, &Phi;-lab, European Space Agency</p>
-        <p>Alistair Francis, University College London</p>
+        <p>Alistair Francis, &Phi;-lab, European Space Agency</p>
         <hr />
         Find more information on
         <a href="https://github.com/ESA-PhiLab/iris" target="_blank">

--- a/iris/help/templates/help.html
+++ b/iris/help/templates/help.html
@@ -56,9 +56,24 @@
         </p>
 
         <p>
-            After you get to annotating, the mask that you and your AI assistant create will be displayed as an overlay on top of the image. This is so that you can see simultaneously your labels and what they correspond
-            to in the data below. Each class will have been assigned a colour by your project administrator. 
+            After you get to annotating, the mask that you and your AI assistant create will be displayed as an overlay on top of the image. This is so that you can simultaneously see your labels and what they correspond
+            to in the data below. Each class will have been assigned a colour by your project administrator. One detail of IRIS that is useful to keep in mind is that there are different versions of the mask available to 
+            visualise:
         </p>
+
+        <ul>
+            <li><b>The final mask<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/mask_final.png')}}" height="15" width="15"/></button>:</b>
+            shows a combination of your annotations and model predictions. This is the view that corresponds to the final saved mask, when you complete your work. Your annotations are always favoured against the model.</li>
+            <li><b>The user mask </b><button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/mask_user.png')}}" height="15" width="15"/></button>:</b>
+            shows only the pixels you have manually annotated. A project will often define one class to be invisible in the final mask (as a way of symbolising some kind of background class), but you should still be able to see the manual labels
+            that you've drawn of that class in the user mask view. This can be useful for checking where you've already annotated, and when erasing annotations.</li>
+             
+            <li><b>The error mask<button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/mask_errors.png')}}" height="15" width="15"/></button>:</b> shows the pixels that the 
+            model has predicted correctly (in green) and incorrectly (in red) for the pixels that are used for validating the models (this view does not include pixels that the model was trained on). This is a useful
+            way to see where the model is making mistakes, and where you should focus your labelling efforts.</li>
+
+
+        </ul>
 
         <br>
         <h2>Getting Started</h2>
@@ -90,7 +105,7 @@
         <h4>5. Display the mask</h4>
         <p>
             IRIS's mask comes from a combination of hand-drawn labels, and AI-generated predictions. When you begin annotating an image, these will be blank, but when they are populated they are displayed as a semi-transparent overlay above 
-            the image views. You can view either the combined predictions between human and model, known as the final mask <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/mask_final.png')}}" height="15" width="15"/></button>/(<span class='key'>F</span>),
+            the image views. You can view either the combined predictions between human and model, known as the final mask <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/mask_final.png')}}" height="15" width="15"/></button>/<span class='key'>F</span>,
             or only the annotations you've made, known as the user mask <button class="icon_button" onclick=""><img src="{{url_for('segmentation.static', filename='icons/mask_user.png')}}" height="15" width="15"/></button>/<span class='key'>G</span>. 
             Try selecting the user mask mode before you begin annotating.
         </p>
@@ -122,8 +137,8 @@
         
         <h4>1. Input -> Output</h4>
         <p>
-            The model only learns from what you give it, so diverse labels will help the model learn about all the different areas in the image, don't just stick to annotating one kind of mistake. Quality over quantity is preferred,
-            as errors in the labels can confuse the model. What you put in is what you get out!
+            The model only learns from what you give it, so diverse labels will help the model learn about all the different areas in the image, don't just stick to annotating one area of the image, or correcting one kind of mistake.
+            Quality over quantity is preferred, as errors in the labels can confuse the model. What you put in is what you get out!
         </p>
 
         <p>
@@ -145,7 +160,7 @@
             isn't necessarily a bad thing, and you will usually find the accuracy <i>decreasing</i> over time, because you are adding more and more difficult labels.
         </p>
 
-        For more tips and advanced use, check out the FAQs.
+        For more tips and advanced use suggestions, check out the FAQs.
 
     </div>
 
@@ -206,7 +221,7 @@
             then the completed ones may be shown to you again). If you do not check the box, then IRIS will keep track of the fact that you would still like to work on this image later.
         </p>
 
-        <br><br>
+        <br>
         <h2>Interacting with the AI</h2>
         <h3>The AI doesn't seem to be learning what I want it to learn</h3>
         <p>

--- a/iris/segmentation/__init__.py
+++ b/iris/segmentation/__init__.py
@@ -323,8 +323,8 @@ def predict_mask(image_id):
 
     # Select only the masking area:
     mask_area = (
-        slice(config['mask_area'][0], config['mask_area'][2]),
         slice(config['mask_area'][1], config['mask_area'][3]),
+        slice(config['mask_area'][0], config['mask_area'][2]),
         slice(None, None, None)
     )
     mask_size = config['mask_shape'][0] * config['mask_shape'][1]

--- a/iris/segmentation/static/javascripts/segmentation.js
+++ b/iris/segmentation/static/javascripts/segmentation.js
@@ -89,7 +89,15 @@ function init_segmentation(){
     // Before we start, we check for the login, etc.
     vars.next_action = init_views;
     fetch_server_update(update_config=true);
-}
+};
+
+function newuser_help_popup(){
+    // Open the help menu if the user is new (no saved masks):
+    if (vars.user.segmentation.n_masks == 0 && vars.just_logged_in == true){
+        dialogue_help();
+        vars.just_logged_in = false;
+    };
+};
 
 async function init_views(){
     show_loader("Loading views...");
@@ -138,6 +146,7 @@ async function init_views(){
 
     get_object("toolbar").style.visibility = "visible";
     get_object("statusbar").style.visibility = "visible";
+    newuser_help_popup();
 }
 
 function init_events(){
@@ -882,6 +891,7 @@ async function fetch_server_update(update_config=true){
     let response = await fetch(vars.url.user+"get/current");
     if (response.status == 403) {
         dialogue_login();
+        vars.just_logged_in=true;
         return;
     }
     let user = await response.json();

--- a/iris/segmentation/static/javascripts/segmentation.js
+++ b/iris/segmentation/static/javascripts/segmentation.js
@@ -1423,7 +1423,7 @@ async function predict_mask(){
     for (let user_class of user_classes){
         tp[user_class] = 0;
     }
-    let n_test_samples = {}; 
+    
     for (let i of test_indices){
         let mask_index = all_user_pixels[i];
         cm[all_user_labels[i]][results.data[mask_index]] += 1;

--- a/iris/segmentation/static/javascripts/segmentation.js
+++ b/iris/segmentation/static/javascripts/segmentation.js
@@ -4,82 +4,107 @@ reasons, i.e. array_2d[y][x] is going to be array_1d[y*row_length+x]*/
 
 let commands = {
     "previous_image": {
-        "key": "Backspace", "description": "Save this image and open previous one",
+        "key": "Backspace",
+        "description": "Save this image and open previous one"
     },
     "next_image": {
-        "key": "Return", "description": "Save this image and open next one",
+        "key": "Return",
+        "description": "Save this image and open next one"
     },
     "save_mask": {
-        "key": "S", "description": "Save this mask",
+        "key": "S",
+        "description": "Save this mask"
     },
     "undo": {
-        "key": "U", "description": "Undo last modification",
+        "key": "U",
+        "description": "Undo last modification"
     },
     "redo": {
-        "key": "R", "description": "Redo modification",
+        "key": "R",
+        "description": "Redo modification"
     },
-    'select_class': {
-        "key": "1 .. 9", "description": "Select class for drawing",
+    "select_class": {
+        "key": "1 .. 9",
+        "description": "Select class for drawing"
     },
-    'tool_move': {
-        "key": "W", "description": "Pan your current view by dragging and moving the cursor",
+    "tool_move": {
+        "key": "W",
+        "description": "Pan your current view by dragging and moving the cursor"
     },
-    'tool_reset_views': {
-        "key": "Z", "description": "Reset the view in the canvases",
+    "tool_reset_views": {
+        "key": "Z",
+        "description": "Reset the view in the canvases"
     },
-    'tool_draw': {
-        "key": "D", "description": "Draw pixels on the mask",
+    "tool_draw": {
+        "key": "D",
+        "description": "Draw pixels on the mask"
     },
-    'tool_eraser': {
-        "key": "E", "description": "Erase previously drawn pixels",
+    "tool_eraser": {
+        "key": "E",
+        "description": "Erase previously drawn pixels"
     },
     "reset_mask": {
-        "key": "N", "description": "Clear the whole mask",
+        "key": "N",
+        "description": "Clear the whole mask"
     },
     "predict_mask": {
-        "key": "A", "description": "Use the AI to help you filling out the mask",
+        "key": "A",
+        "description": "Use the AI to help you filling out the mask"
     },
     "toogle_mask": {
-        "key": "Space", "description": "Toggle mask on/off",
+        "key": "Space",
+        "description": "Toggle mask on/off"
     },
     "mask_final": {
-        "key": "F", "description": "Show the final mask combined from your pixels and the predictions by the AI",
+        "key": "F",
+        "description": "Show the final mask combined from your pixels and the predictions by the AI"
     },
     "mask_user": {
-        "key": "G", "description": "Show your drawn pixels only",
+        "key": "G",
+        "description": "Show your drawn pixels only"
     },
     "mask_errors": {
-        "key": "H", "description": "Show where the AI failed to predict correctly",
+        "key": "H",
+        "description": "Show where the AI failed to predict correctly"
     },
     // "mask_highlight_edges": {
     //     "key": "B", "description": "Highlight edges on the masks",
     // },
     "toggle_contrast": {
-        "key": "C", "description": "Toggle contrast on/off",
+        "key": "C", 
+        "description": "Toggle contrast on/off"
     },
     "toggle_invert": {
-        "key": "I", "description": "Toggle inversion on/off",
+        "key": "I", 
+        "description": "Toggle inversion on/off"
     },
     "brightness_up": {
-        "key": "Arrow-Up", "description": "Increase brightness (+10%)",
+        "key": "Arrow-Up", 
+        "description": "Increase brightness (+10%)"
     },
     "brightness_down": {
-        "key": "Arrow-Down", "description": "Decrease brightness (-10%)",
+        "key": "Arrow-Down", 
+        "description": "Decrease brightness (-10%)"
     },
     "saturation_up": {
-        "key": "Arrow-Right", "description": "Increase saturation (+50%)",
+        "key": "Arrow-Right",
+        "description": "Increase saturation (+50%)"
     },
     "saturation_down": {
-        "key": "Arrow-Left", "description": "Decrease saturation (-50%)",
+        "key": "Arrow-Left",
+        "description": "Decrease saturation (-50%)"
     },
     "reset_filters": {
-        "key": "X", "description": "Reset all image filters",
+        "key": "X",
+        "description": "Reset all image filters"
     },
     "show_view_controls": {
-        "key": "V", "description": "Toogle display of view controls on/off"
+        "key": "V",
+        "description":"Toogle display of view controls on/off"
     },
     "next_view_group": {
-        "key": "B", "description": "Switch to next group view"
+        "key": "B",
+        "description": "Switch to next group view"
     }
 };
 
@@ -89,17 +114,17 @@ function init_segmentation(){
     // Before we start, we check for the login, etc.
     vars.next_action = init_views;
     fetch_server_update(update_config=true);
-};
+}
 
 function newuser_help_popup(){
     // Open the help menu if the user is new (no saved masks):
     if (vars.user.segmentation.n_masks == 0 && vars.just_logged_in == true){
         dialogue_help();
         vars.just_logged_in = false;
-    };
-};
+    }
+}
 
-async function init_views(){
+function init_views(){
     show_loader("Loading views...");
     vars.vm = new ViewManager(
         get_object('views-container'),
@@ -111,11 +136,11 @@ async function init_views(){
     vars.vm.addStandardLayer(
         MaskLayer,
         (view) => view.type != "bingmap"
-    )
+    );
     vars.vm.addStandardLayer(
         PreviewLayer,
         (view) => view.type != "bingmap"
-    )
+    );
 
     // It much faster to change some pixel values on a sprite and draw it then
     // to the canvas once than redrawing each pixel to the canvas directly.
@@ -1079,9 +1104,7 @@ async function dialogue_help(){
         vars.url.help, {
             method: "POST",
             body: JSON.stringify({
-                "hotkeys": hotkeys,
-                "page": "Segmentation",
-                "page_content": "segmentation/help.html"
+                "hotkeys": hotkeys
             })
         }
     );

--- a/iris/segmentation/static/javascripts/segmentation.js
+++ b/iris/segmentation/static/javascripts/segmentation.js
@@ -129,7 +129,8 @@ function init_views(){
     vars.vm = new ViewManager(
         get_object('views-container'),
         vars.config.views, vars.config.view_groups,
-        vars.url.main+"image/"
+        vars.url.main+"image/",
+        image_aspect_ratio=vars.image_shape[0]/vars.image_shape[1]
     );
 
     // Add standard layers to all view ports if the view type is not "bingmap":
@@ -462,7 +463,7 @@ function constrain_view(ctx, scale, dx, dy){
         // it to the default view
 
         transforms.a = ctx.canvas.width / vars.image_shape[0];
-        transforms.d = ctx.canvas.width / vars.image_shape[0];
+        transforms.d = ctx.canvas.height / vars.image_shape[1];
         transforms.b = 0;
         transforms.c = 0;
         transforms.e = 0;

--- a/iris/segmentation/templates/segmentation.html
+++ b/iris/segmentation/templates/segmentation.html
@@ -138,10 +138,10 @@
         <li class="toolbutton icon_button" id='tb_saturation_down' onclick="change_saturation(up=false);">
             <img src={{url_for('segmentation.static', filename='icons/saturation_down.png')}} class="icon" />
         </li>
-        <li class="toolbutton icon_button" id='tb_toggle_contrast' onclick="set_contrast(!vars.contrast);">
+        <li class="toolbutton icon_button" id='tb_toggle_contrast' onclick="set_contrast(!vars.vm.filters.contrast);">
             <img src={{url_for('segmentation.static', filename='icons/contrast.png')}} class="icon" />
         </li>
-        <li class="toolbutton icon_button" id='tb_toggle_invert' onclick="set_invert(!vars.invert);">
+        <li class="toolbutton icon_button" id='tb_toggle_invert' onclick="set_invert(!vars.vm.filters.invert);">
             <img src={{url_for('segmentation.static', filename='icons/invert.png')}} class="icon" />
         </li>
         <li class="toolbutton icon_button" id="tb_reset_filters" onclick='reset_filters();'>

--- a/iris/segmentation/templates/segmentation/help.html
+++ b/iris/segmentation/templates/segmentation/help.html
@@ -1,7 +1,0 @@
-<h3>FAQ</h3>
-<h4>How can I change the size of the pencil?</h4>
-Press <span class="key">Shift</span> while scrolling the mouse wheel.
-<h4>I would like to undo some changes. How can I do that?</h4>
-Use either the <b>undo</b> command (<span class="key">U</span>) or the eraser tool (<span class="key">E</span>).
-<h4>How can I select another class for drawing?</h4>
-Use either the number hotkeys (<span class="key">1..9</span>) or click in the toolbar on the <button class="icon_button" onclick="dialogue_class_selection();"><img src="{{url_for('segmentation.static', filename='icons/class.png')}}" height="18" width="18"/></button> button.

--- a/iris/static/css/main.css
+++ b/iris/static/css/main.css
@@ -252,21 +252,21 @@ button:hover,.button:hover,.toolbutton:hover,.statusbutton:hover{
 table {
   /* width: 100%; */
   border-collapse: collapse;
-  border-color: #8D8D8D;
+  border-color: #8d8d8d;
   margin: 2px 2px;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.18);
   position: relative;
 }
 
 table.striped tr:nth-child(even){
-  background-color: #FBF8E0; /* Cream rows */
+  background-color: #fdfbe7; /* Cream rows */
 }
 
 td, th {
   border: 1px solid #000;
   padding: 8px;
   border-style: outset;
-  border-color: #9D9D9D;
+  border-color: #9d9d9d;
   text-align: center;
   position: relative;
 }

--- a/iris/static/javascripts/views.js
+++ b/iris/static/javascripts/views.js
@@ -113,12 +113,10 @@ class ViewManager{
             allowed_width,
             allowed_height * this.image_aspect_ratio,
         );
-
         let ideal_height = Math.min(
             ideal_width / this.image_aspect_ratio,
             allowed_height
         );
-        // ideal_height -= 200;
         
         // if limited horizontally, does not scale
         // if limited vertically, scales DOWN by that factor
@@ -127,19 +125,8 @@ class ViewManager{
             ideal_height / allowed_height
             );
 
-            
         let width = round_number(ideal_width / scale_from_vertical_limit);
         let height = round_number(width / this.image_aspect_ratio);
-        
-
-        console.log('allowed_width', allowed_width)
-        console.log('allowed_height', allowed_height)
-        console.log("ideal_width", ideal_width)
-        console.log("ideal_height", ideal_height)
-        console.log("scale_from_vertical_limit", scale_from_vertical_limit)
-        console.log("width", width)
-        console.log("height", height)
-
             
         return [width, height];
     }

--- a/iris/static/javascripts/views.js
+++ b/iris/static/javascripts/views.js
@@ -252,14 +252,18 @@ class ViewPort{
         this.button_add.onclick = () => {vm.addView(view.name, id);};
         this.controls.appendChild(this.button_add);
 
-        this.button_remove = document.createElement('button');
-        this.button_remove.classList.add("view-controls");
-        this.button_remove.innerHTML = "-";
-        this.button_remove.style.right = "50px";
-        this.button_remove.style.top = "10px";
-        this.button_remove.onclick = () => {vm.removeView(id);};
-        this.controls.appendChild(this.button_remove);
-
+        // Don't allow user to remove final view from group
+        if (vm.getCurrentViews().length>1){
+            this.button_remove = document.createElement('button');
+            this.button_remove.classList.add("view-controls");
+            this.button_remove.innerHTML = "-";
+            this.button_remove.style.right = "50px";
+            this.button_remove.style.top = "10px";
+            this.button_remove.onclick = () => {vm.removeView(id);};
+            this.controls.appendChild(this.button_remove);
+        } else {
+            this.button_remove = null;
+        }
         this.select_view = document.createElement('select');
         this.select_view.classList.add("view-controls");
         this.select_view.classList.add("with-arrow");


### PR DESCRIPTION
Large extension to help menu, providing step-by-step guide for annotators which is general-purpose for all projects. 

As well as this improvement, several bug fixes were found and have been fixed:

 **1. Non-square images**
> IRIS now handles non-square imagery.

**2. Higher resolution**
> IRIS' views were previously held at a fixed resolution (independent of screen resolution). They are now set to the resolution of the screen to make the images as sharp as possible.

**3. View group protection**
>  Previously, a user could delete the last view in a view group, leaving them with an empty view group that could not be added to. Now the view removal button is only visible when >1 views exist

**4. Validation calculation**
> IRIS holds a certain number of pixels back from the model during training, to use them in validation. However, previously the validation accuracy and confusion matrix were computed on training set. Now using the validation set as was originally intended.

**5. Contrast/Inversion toggling.**
> Button toggling now works for contrast and inversion.