### PR TITLE
Add vmin/vmax option to config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -149,9 +149,10 @@ Since this app was developed for multi-spectral satellite data (i.e. images with
     <li>
         *clip:* By default, bands are stretched between 0 and 1, relative to their minimum and maximum values. By setting a value for clip, you control the percentile of pixels that are saturated at 0 and 1, which can be helpful if there are some extreme pixel values that reduce the contrast in other parts of the image.
     </li>
+    <li>
+        *vmin/vmax* If you know the precise values you would like to clip the pixel values to, (rather than a percentile), then you can specify these with vmin and/or vmax. This cannot be used for the same view as `clip`.
+    </li>
 </ul>
-
-IRIS can display up to 4 views until v0.1. From v0.2 it can display an arbitrary number of views.
 
 <i>Example:</i>
 ```

--- a/iris/project.py
+++ b/iris/project.py
@@ -359,12 +359,21 @@ class Project:
 
         # Stretch between 0->1, with percentile clip if specified in view
         if 'clip' in view:
+            if 'vmin' in view or 'vmax' in view:
+                raise ValueError("Cannot specify both 'clip' and 'vmin'/'vmax' in view")
             clip = float(view['clip'])
             linear_scale = lambda z: np.clip(
                 (z - np.percentile(z,clip))/(np.percentile(z,100-clip)-np.percentile(z,clip)),
                 0,
                 1
                 )
+        elif 'vmin' in view or 'vmax' in view:
+            if 'vmin' in view and 'vmax' in view:
+                linear_scale = lambda z: np.clip((z - view['vmin'])/(view['vmax']-view['vmin']), 0, 1)
+            elif 'vmin' in view:
+                linear_scale = lambda z: np.clip((z - view['vmin'])/(z.max()-view['vmin']), 0, 1)
+            elif 'vmax' in view:
+                linear_scale = lambda z: np.clip((z - z.min())/(view['vmax']-z.min()), 0, 1)
         else:
             linear_scale = lambda z: (z - z.min())/(z.max()-z.min())
         rgb_bands = list(map(linear_scale, rgb_bands))


### PR DESCRIPTION
Gives option to use vmin and vmax in view definitions. This is helpful if you know beforehand the physical values you want to constrain (e.g. NDVI clipped to a value of 0)