### PR TITLE
Python package compatibiliy fixes

### DIFF
--- a/iris/admin/__init__.py
+++ b/iris/admin/__init__.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from datetime import timedelta
 
 import flask
+import markupsafe
 from sqlalchemy import func
 
 from iris.user import requires_admin, requires_auth
@@ -44,7 +45,7 @@ def users():
     users_json = [user.to_json() for user in users]
 
     html = flask.render_template('admin/users.html', users=users_json, order_by=order_by, ascending=ascending)
-    return flask.render_template('admin/index.html', user=user, page=flask.Markup(html))
+    return flask.render_template('admin/index.html', user=user, page=markupsafe.Markup(html))
 
 @admin_app.route('/actions/<type>', methods=['GET'])
 @requires_auth
@@ -74,7 +75,7 @@ def actions(type):
         'admin/actions.html', action_type=type, actions=actions_json,
         image_stats=image_stats, order_by=order_by, ascending=ascending
     )
-    return flask.render_template('admin/index.html', user=user, page=flask.Markup(html))
+    return flask.render_template('admin/index.html', user=user, page=markupsafe.Markup(html))
 
 @admin_app.route('/images', methods=['GET'])
 @requires_auth
@@ -117,4 +118,4 @@ def images():
     html = flask.render_template(
         'admin/images.html', images=images, order_by=order_by, ascending=ascending
     )
-    return flask.render_template('admin/index.html', user=user, page=flask.Markup(html))
+    return flask.render_template('admin/index.html', user=user, page=markupsafe.Markup(html))

--- a/iris/main/__init__.py
+++ b/iris/main/__init__.py
@@ -2,6 +2,7 @@ import io
 import json
 
 import flask
+import markupsafe
 import numpy as np
 from PIL import Image as PILImage
 from skimage.transform import resize
@@ -92,7 +93,7 @@ def metadata(image_id):
 
     if flask.request.args.get('safe_html', False):
         metadata = {
-            k: flask.Markup(str(v))
+            k: markupsafe.Markup(str(v))
             for k, v in metadata.items()
         }
 

--- a/iris/project.py
+++ b/iris/project.py
@@ -10,6 +10,8 @@ from pprint import pprint
 import re
 
 import flask
+import markupsafe
+
 import json
 from matplotlib import cm
 import numpy as np
@@ -95,7 +97,7 @@ class Project:
         # Make sure the HTML is understood in the descriptions:
         for name, view in self.config['views'].items():
             view['name'] = name
-            view['description'] = flask.Markup(
+            view['description'] = markupsafe.Markup(
                 view.get('description', view['name'])
             )
             view['stretch'] = view.get('stretch', 'linear')

--- a/iris/segmentation/__init__.py
+++ b/iris/segmentation/__init__.py
@@ -272,7 +272,7 @@ def save_mask(image_id):
     # The user mask denotes who classified the pixels in the mask:
     #   if true: the user classified the pixel
     #   if false: the AI classified the pixel
-    user_mask = data[1+mask_length:-1].astype(np.bool)
+    user_mask = data[1+mask_length:-1].astype(bool)
     user_mask = user_mask.reshape(project['segmentation']['mask_shape'][::-1])
 
     final_mask_file, user_mask_file = get_mask_filenames(image_id, user_id)

--- a/iris/utils.py
+++ b/iris/utils.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 
 import flask
-
+import markupsafe
 
 
 class View:
@@ -12,8 +12,8 @@ class View:
 
     def to_json(self):
         return {
-            'name': flask.Markup(self.name),
-            'description': flask.Markup(self.description),
+            'name': markupsafe.Markup(self.name),
+            'description': markupsafe.Markup(self.description),
         }
 
 def merge_deep_dicts(d1, d2):


### PR DESCRIPTION
These two patches fix compatibility with Flask 3 and numpy 1.24.0 dependencies in Iris by rewriting deprecated constructs.

These fixes should be backwards compatible with Flask 2 and numpy 1.23, so there was no need to patch requirements.txt.
